### PR TITLE
Adjust plugin spec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
       matrix:
         ruby:
           - head
+          - 3.0
+          - 2.7
 
     steps:
     - uses: actions/checkout@v2
@@ -23,5 +25,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+    - name: Set up dependencies
+      run: sudo apt install graphviz && gem install ruby-graphviz
     - name: Run the default task
       run: bundle exec rake

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--color
+--warnings
+--require spec_helper
+--order random

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "rspec"
+gem "ruby-graphviz"

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,5 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in bundler-viz.gemspec
-gemspec
-
-gem "rake", "~> 13.0"
-
-gem "minitest", "~> 5.0"
+gem "rake"
+gem "rspec"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ bundle graph [--file=FILE]
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
-require "rake/testtask"
+require 'rspec/core/rake_task'
 
-Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"]
-end
+RSpec::Core::RakeTask.new(:spec)
 
-task default: :test
+task default: :spec
+kk

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,3 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
-kk

--- a/bundler-graph.gemspec
+++ b/bundler-graph.gemspec
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "lib/bundler/graph/version"
-
 Gem::Specification.new do |spec|
   spec.name          = "bundler-graph"
-  spec.version       = Bundler::Graph::VERSION
+  spec.version       = "0.1.0"
   spec.authors       = ["Hiroshi SHIBATA"]
   spec.email         = ["hsbt@ruby-lang.org"]
 

--- a/lib/bundler/dep_graph.rb
+++ b/lib/bundler/dep_graph.rb
@@ -2,7 +2,7 @@
 
 require "set"
 module Bundler
-  class Graph
+  class DepGraph
     GRAPH_NAME = :Gemfile
 
     def initialize(env, output_file, show_version = false, show_requirements = false, output_format = "png", without = [])

--- a/lib/bundler/graph_cli.rb
+++ b/lib/bundler/graph_cli.rb
@@ -23,11 +23,11 @@ module Bundler
         without: []
       }
       opt = OptionParser.new
-      opt.on('-f', '--file', 'The name to use for the generated file. See `--format` option') {|v| options[:file] = v }
-      opt.on('-F', '--format', 'This is output format option. Supported format is png, jpg, svg, dot ...') {|v| options[:format] = v }
+      opt.on('-f', '--file FILE', 'The name to use for the generated file. See `--format` option') {|v| options[:file] = v }
+      opt.on('-F', '--format FORMAT', 'This is output format option. Supported format is png, jpg, svg, dot ...') {|v| options[:format] = v }
       opt.on('-R', '--requirements', 'Set to show the version of each required dependency.') {|v| options[:requirements] = true }
       opt.on('-v', '--version', 'Set to show each gem version.') {|v| options[:version] = true }
-      opt.on('-W', '--without', 'Exclude gems that are part of the specified named group.') {|v| options[:without] = v }
+      opt.on('-W', '--without GROUP[,GROUP...]', 'Exclude gems that are part of the specified named group.') {|v| options[:without] = v }
       opt.parse!(argv)
 
       options[:without] = options[:without].join(":").tr(" ", ":").split(":")

--- a/lib/bundler/graph_cli.rb
+++ b/lib/bundler/graph_cli.rb
@@ -2,7 +2,7 @@
 
 require "bundler/plugin/api"
 require "optparse"
-require_relative "graph"
+require_relative "dep_graph"
 
 module Bundler
   class GraphCLI < Plugin::API
@@ -33,7 +33,7 @@ module Bundler
       options[:without] = options[:without].join(":").tr(" ", ":").split(":")
       output_file = File.expand_path(options[:file])
 
-      graph = Graph.new(Bundler.load, output_file, options[:version], options[:requirements], options[:format], options[:without])
+      graph = DepGraph.new(Bundler.load, output_file, options[:version], options[:requirements], options[:format], options[:without])
       graph.viz
     rescue LoadError => e
       Bundler.ui.error e.inspect

--- a/lib/bundler/graph_cli.rb
+++ b/lib/bundler/graph_cli.rb
@@ -20,17 +20,17 @@ module Bundler
         format: "png",
         requirements: false,
         version: false,
-        without: []
+        without: ""
       }
       opt = OptionParser.new
       opt.on('-f', '--file FILE', 'The name to use for the generated file. See `--format` option') {|v| options[:file] = v }
       opt.on('-F', '--format FORMAT', 'This is output format option. Supported format is png, jpg, svg, dot ...') {|v| options[:format] = v }
       opt.on('-R', '--requirements', 'Set to show the version of each required dependency.') {|v| options[:requirements] = true }
       opt.on('-v', '--version', 'Set to show each gem version.') {|v| options[:version] = true }
-      opt.on('-W', '--without GROUP[,GROUP...]', 'Exclude gems that are part of the specified named group.') {|v| options[:without] = v }
+      opt.on('-W', '--without GROUP[:GROUP...]', 'Exclude gems that are part of the specified named group.') {|v| options[:without] = v }
       opt.parse!(argv)
 
-      options[:without] = options[:without].join(":").tr(" ", ":").split(":")
+      options[:without] = options[:without].tr(" ", ":").split(":")
       output_file = File.expand_path(options[:file])
 
       graph = DepGraph.new(Bundler.load, output_file, options[:version], options[:requirements], options[:format], options[:without])

--- a/spec/commands/graph_spec.rb
+++ b/spec/commands/graph_spec.rb
@@ -17,12 +17,11 @@ RSpec.describe "bundle graph" do
   end
 
   let(:base_gemfile) do
-    bundler_graph_root = Pathname.new(__dir__).join("..").expand_path
+    bundler_graph_root = Pathname.new(__dir__).join("../..").expand_path
 
     <<~G.chomp
       source "https://rubygems.org"
-      plugin "bundler-graph", :git => #{bundler_graph_root.to_s.inspect}, :ref => "HEAD"
-      require File.join(Bundler::Plugin.index.load_paths("bundler-graph")[0], "bundler-graph") rescue nil
+      plugin "bundler-graph", :path => "#{bundler_graph_root.to_s}"
     G
   end
 

--- a/spec/commands/graph_spec.rb
+++ b/spec/commands/graph_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "bundle graph" do
   it "graphs gems that are prereleases" do
     install_gemfile <<-G
       #{base_gemfile}
-      gem "rack", "= 1.3.pre"
+      gem "rack", "= 1.3.0.beta"
       gem "rack-obama"
     G
 
@@ -75,9 +75,9 @@ RSpec.describe "bundle graph" do
       node[ fontname  =  "Arial, Helvetica, SansSerif"];
       edge[ fontname  =  "Arial, Helvetica, SansSerif" , fontsize  =  "12"];
       default [style = "filled", fillcolor = "#B9B9D5", shape = "box3d", fontsize = "16", label = "default"];
-      rack [style = "filled", fillcolor = "#B9B9D5", label = "rack\\n1.3.pre"];
+      rack [style = "filled", fillcolor = "#B9B9D5", label = "rack\\n1.3.0.beta"];
         default -> rack [constraint = "false"];
-      "rack-obama" [style = "filled", fillcolor = "#B9B9D5", label = "rack-obama\\n1.0"];
+      "rack-obama" [style = "filled", fillcolor = "#B9B9D5", label = "rack-obama\\n0.1.1"];
         default -> "rack-obama" [constraint = "false"];
         "rack-obama" -> rack;
       }

--- a/spec/commands/graph_spec.rb
+++ b/spec/commands/graph_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+require 'pathname'
+
 RSpec.describe "bundle graph" do
   before do
     @org_dir = Dir.pwd

--- a/spec/commands/graph_spec.rb
+++ b/spec/commands/graph_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
+RSpec.describe "bundle graph", :bundler => "< 3", :if => Bundler.which("dot") do
   let(:ruby_graphviz) do
     graphviz_glob = base_system_gems.join("cache/ruby-graphviz*")
     Pathname.glob(graphviz_glob).first
@@ -17,10 +17,10 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
       gem "rack-obama"
     G
 
-    bundle! "viz"
+    bundle! "graph"
     expect(out).to include("gem_graph.png")
 
-    bundle! "viz", :format => "debug"
+    bundle! "graph", :format => "debug"
     expect(out).to eq(strip_whitespace(<<-DOT).strip)
       digraph Gemfile {
       concentrate = "true";
@@ -51,10 +51,10 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
       gem "rack-obama"
     G
 
-    bundle! "viz"
+    bundle! "graph"
     expect(out).to include("gem_graph.png")
 
-    bundle! "viz", :format => :debug, :version => true
+    bundle! "graph", :format => :debug, :version => true
     expect(out).to eq(strip_whitespace(<<-EOS).strip)
       digraph Gemfile {
       concentrate = "true";
@@ -92,7 +92,7 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
         gem "rack-obama"
       G
 
-      bundle! "viz", :format => "debug"
+      bundle! "graph", :format => "debug"
       expect(out).to eq(strip_whitespace(<<-DOT).strip)
         digraph Gemfile {
         concentrate = "true";
@@ -124,7 +124,7 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
         end
       G
 
-      bundle! "viz --without=rails"
+      bundle! "graph --without=rails"
       expect(out).to include("gem_graph.png")
     end
 
@@ -142,7 +142,7 @@ RSpec.describe "bundle viz", :bundler => "< 3", :if => Bundler.which("dot") do
         end
       G
 
-      bundle! "viz --without=rails:rack"
+      bundle! "graph --without=rails:rack"
       expect(out).to include("gem_graph.png")
     end
   end

--- a/spec/commands/graph_spec.rb
+++ b/spec/commands/graph_spec.rb
@@ -1,26 +1,39 @@
 # frozen_string_literal: true
 
-RSpec.describe "bundle graph", :bundler => "< 3", :if => Bundler.which("dot") do
-  let(:ruby_graphviz) do
-    graphviz_glob = base_system_gems.join("cache/ruby-graphviz*")
-    Pathname.glob(graphviz_glob).first
+RSpec.describe "bundle graph" do
+  before do
+    @org_dir = Dir.pwd
+    app_dir = File.join(Dir.pwd, "tmp/bundled_app")
+    FileUtils.rm_rf(app_dir)
+    FileUtils.mkdir_p(app_dir)
+    Dir.chdir(app_dir)
   end
 
-  before do
-    system_gems ruby_graphviz
+  after do
+    Dir.chdir(@org_dir)
+  end
+
+  let(:base_gemfile) do
+    bundler_graph_root = Pathname.new(__dir__).join("..").expand_path
+
+    <<~G.chomp
+      source "https://rubygems.org"
+      plugin "bundler-graph", :git => #{bundler_graph_root.to_s.inspect}, :ref => "HEAD"
+      require File.join(Bundler::Plugin.index.load_paths("bundler-graph")[0], "bundler-graph") rescue nil
+    G
   end
 
   it "graphs gems from the Gemfile" do
     install_gemfile <<-G
-      source "#{file_uri_for(gem_repo1)}"
+      #{base_gemfile}
       gem "rack"
       gem "rack-obama"
     G
 
-    bundle! "graph"
+    out = run_command "bundle graph"
     expect(out).to include("gem_graph.png")
 
-    bundle! "graph", :format => "debug"
+    out = run_command "bundle graph --format debug"
     expect(out).to eq(strip_whitespace(<<-DOT).strip)
       digraph Gemfile {
       concentrate = "true";
@@ -41,20 +54,16 @@ RSpec.describe "bundle graph", :bundler => "< 3", :if => Bundler.which("dot") do
   end
 
   it "graphs gems that are prereleases" do
-    build_repo2 do
-      build_gem "rack", "1.3.pre"
-    end
-
     install_gemfile <<-G
-      source "#{file_uri_for(gem_repo2)}"
+      #{base_gemfile}
       gem "rack", "= 1.3.pre"
       gem "rack-obama"
     G
 
-    bundle! "graph"
+    out = run_command "bundle graph"
     expect(out).to include("gem_graph.png")
 
-    bundle! "graph", :format => :debug, :version => true
+    out = run_command "bundle graph --format debug --version"
     expect(out).to eq(strip_whitespace(<<-EOS).strip)
       digraph Gemfile {
       concentrate = "true";
@@ -74,49 +83,10 @@ RSpec.describe "bundle graph", :bundler => "< 3", :if => Bundler.which("dot") do
     EOS
   end
 
-  context "with another gem that has a graphviz file" do
-    before do
-      build_repo4 do
-        build_gem "graphviz", "999" do |s|
-          s.write("lib/graphviz.rb", "abort 'wrong graphviz gem loaded'")
-        end
-      end
-
-      system_gems ruby_graphviz, "graphviz-999", :gem_repo => gem_repo4
-    end
-
-    it "loads the correct ruby-graphviz gem" do
-      install_gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
-        gem "rack"
-        gem "rack-obama"
-      G
-
-      bundle! "graph", :format => "debug"
-      expect(out).to eq(strip_whitespace(<<-DOT).strip)
-        digraph Gemfile {
-        concentrate = "true";
-        normalize = "true";
-        nodesep = "0.55";
-        edge[ weight  =  "2"];
-        node[ fontname  =  "Arial, Helvetica, SansSerif"];
-        edge[ fontname  =  "Arial, Helvetica, SansSerif" , fontsize  =  "12"];
-        default [style = "filled", fillcolor = "#B9B9D5", shape = "box3d", fontsize = "16", label = "default"];
-        rack [style = "filled", fillcolor = "#B9B9D5", label = "rack"];
-          default -> rack [constraint = "false"];
-        "rack-obama" [style = "filled", fillcolor = "#B9B9D5", label = "rack-obama"];
-          default -> "rack-obama" [constraint = "false"];
-          "rack-obama" -> rack;
-        }
-        debugging bundle viz...
-      DOT
-    end
-  end
-
   context "--without option" do
     it "one group" do
       install_gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
+        #{base_gemfile}
         gem "activesupport"
 
         group :rails do
@@ -124,13 +94,13 @@ RSpec.describe "bundle graph", :bundler => "< 3", :if => Bundler.which("dot") do
         end
       G
 
-      bundle! "graph --without=rails"
+      out = run_command "bundle graph --without=rails"
       expect(out).to include("gem_graph.png")
     end
 
     it "two groups" do
       install_gemfile <<-G
-        source "#{file_uri_for(gem_repo1)}"
+        #{base_gemfile}
         gem "activesupport"
 
         group :rack do
@@ -142,7 +112,7 @@ RSpec.describe "bundle graph", :bundler => "< 3", :if => Bundler.which("dot") do
         end
       G
 
-      bundle! "graph --without=rails:rack"
+      out = run_command "bundle graph --without=rails:rack"
       expect(out).to include("gem_graph.png")
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
+
+RSpec.configure do |c|
+  c.include Spec::Helpers
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require "bundler/setup"
+
 Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |c|

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -17,7 +17,7 @@ module Spec
 
         raise StandardError, "#{command} failed: #{output}" unless status.success?
       end
-      output
+      output.chomp
     end
 
     # https://github.com/rubygems/rubygems/blob/master/bundler/spec/support/helpers.rb#L271

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -19,5 +19,12 @@ module Spec
       end
       output
     end
+
+    # https://github.com/rubygems/rubygems/blob/master/bundler/spec/support/helpers.rb#L271
+    def strip_whitespace(str)
+      # Trim the leading spaces
+      spaces = str[/\A\s+/, 0] || ""
+      str.gsub(/^#{spaces}/, "")
+    end
   end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,23 @@
+require "open3"
+
+# https://github.com/duckinator/bundler-viz/blob/master/test/visualize_test.rb#L126
+module Spec
+  module Helpers
+    def install_gemfile(content)
+      File.open("Gemfile", "w") do |f|
+        f.write(content)
+      end
+      run_command("bundle install")
+    end
+
+    def run_command(command)
+      output = nil
+      Bundler.with_unbundled_env do
+        output, status = Open3.capture2e(command)
+
+        raise StandardError, "#{command} failed: #{output}" unless status.success?
+      end
+      output
+    end
+  end
+end


### PR DESCRIPTION
The current spec examples depends on bundler test suite. We should migrate it to the plugin spec suite.