### PR TITLE
Add Ruby 3.1 to CI test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,12 @@ jobs:
       matrix:
         ruby:
           - head
-          - 3.0
+          - 3.1
+          - '3.0'
           - 2.7
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Actually this PR adds Ruby 3.0 to the matrix since ruby "3.0" indicates ruby 3.1.2 as of this PR.

Also `actions/checkout` action is updated from v2 to v3.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)