### PR TITLE
Handle non-installed gems

### DIFF
--- a/lib/bundler/dep_graph.rb
+++ b/lib/bundler/dep_graph.rb
@@ -36,11 +36,18 @@ module Bundler
 
         tmp = Set.new
         parent_dependencies.each do |dependency|
-          child_dependencies = spec_for_dependency(dependency).runtime_dependencies.to_set
+          @node_options[dependency.name] = _make_label(dependency, :node)
+
+          spec = spec_for_dependency(dependency)
+          if spec.nil?
+            $stderr.puts "Could not find dependency #{dependency.name} [group: #{dependency.groups.join(", ")}]"
+            next
+          end
+
+          child_dependencies = spec.runtime_dependencies.to_set
           @relations[dependency.name] += child_dependencies.map(&:name).to_set
           tmp += child_dependencies
 
-          @node_options[dependency.name] = _make_label(dependency, :node)
           child_dependencies.each do |c_dependency|
             @edge_options["#{dependency.name}_#{c_dependency.name}"] = _make_label(c_dependency, :edge)
           end


### PR DESCRIPTION
When there are production gems that are not installed in development, graph will not be able to find the gem.

Unfortunately, there is no information available to fix the issue other than open the gem and add a `rescue` / `puts`.

Before
======

It threw an exception without any actionable information.

```
[master] manageiq $ bundle graph -W test:development --format svg

--- ERROR REPORT TEMPLATE -------------------------------------------------------
NoMethodError: undefined method `runtime_dependencies' for nil
  /Users/kbrock/.gem/ruby/3.3.4/gems/bundler-graph-0.2.1/lib/bundler/dep_graph.rb:47:in `block (2 levels) in _populate_relations'
          /Users/kbrock/.rubies/ruby-3.3.4/lib/ruby/3.3.0/set.rb:501:in `each_key'
          /Users/kbrock/.rubies/ruby-3.3.4/lib/ruby/3.3.0/set.rb:501:in `each'
          /Users/kbrock/.gem/ruby/3.3.4/gems/bundler-graph-0.2.1/lib/bundler/dep_graph.rb:38:in `block in _populate_relations'
          <internal:kernel>:187:in `loop'
...
--- TEMPLATE END ----------------------------------------------------------------

Unfortunately, an unexpected error occurred, and Bundler cannot continue.
...
```

After
======

```
[master] manageiq $ bundle graph -W test:development --format svg

Could not find dependency qpid_proton [group: qpid_proton]
Could not find dependency dbus-systemd [group: systemd]
Could not find dependency sd_notify [group: systemd]
Could not find dependency systemd-journal [group: systemd]
Could not find dependency irb [group: appliance]
Could not find dependency manageiq-appliance_console [group: appliance]
Could not find dependency rdoc [group: appliance]

/Users/kbrock/src/manageiq/gem_graph.svg

[master] manageiq $ bundle graph -W test:development:qpid_proton:systemd:appliance --format svg

/Users/kbrock/src/manageiq/gem_graph.svg

[master] manageiq $
```

DISCLAIMER: I did add a few blank lines in this PR to make the output easier to read. Those are not in the actual output.
